### PR TITLE
allow usage from machines other than localhost

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -18,7 +18,8 @@ var defaultValues = {
   proxy: '',
   verbose: false,
   liveCSS: true,
-  liveImg: true
+  liveImg: true,
+  hostname: 'localhost'
 };
 
 program
@@ -27,6 +28,7 @@ program
   .option('--exclude <pattern>', 'exclude file matching pattern')
   .option('--include <pattern>', 'don\'t exclude file matching pattern')
   .option('-p, --port <port>', 'change wait port', parseInt)
+  .option('--hostname <hostname>', 'change server hostname, set to `null` to access from external machines')
   .option('-l, --prefer-local', 'return a local file if it exists (proxy mode only)')
   .option('-s, --static', 'enable static server mode')
   .option('-v, --verbose', 'enable verbose log')

--- a/lib/server.js
+++ b/lib/server.js
@@ -89,7 +89,7 @@ Server.prototype = {
       response.write("File not found");
       response.end();
       log.debug("404 %s", request.url);
-    }).listen(this.config.port);
+    }).listen(this.config.port, (this.config.hostname === '*' ? null : this.config.hostname));
 
     this.webSocket = new WebSocketHandler(this.config, { server: server });
 


### PR DESCRIPTION
Hi,

great tool for cross platform livereload.
I wanted to run the server on my development box (virtualized ubuntu) and browse the website on chrome for windows, ie: make the server listen to hosts other than `localhost`.

With this patch it's possibile to issue:

```
livereloadx --hostname=*
```

from the command line and the server will listen from connection coming from other machines.

**Note:**

Chrome extension still injects a script pointing to `http://localhost:...` so you'll need to add the snippet manually to your pages.

On that side a good technique to prevent blocking page load if the livereload server is down or slow, would be to replace the `document.write` snippet with its async version:

``` html
<script>
        (function () {
            var w = document.createElement('script');
            w.type = 'text/javascript';
            w.async = true;
            w.src = 'http://' + (location.host || 'localhost').split(':')[0] + ':35729/livereload.js?snipver=2';
            var s = document.getElementsByTagName('script')[0];
            s.parentNode.insertBefore(w, s);
        }());
</script>
```
