### PR TITLE
Push State functionality for static server

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -16,6 +16,7 @@ var defaultValues = {
   port: 35729,
   preferLocal: false,
   proxy: '',
+  pushstate: false,
   verbose: false,
   liveCSS: true,
   liveImg: true
@@ -29,6 +30,7 @@ program
   .option('-p, --port <port>', 'change wait port', function(val){ return parseInt(val, 10); })
   .option('-l, --prefer-local', 'return a local file if it exists (proxy mode only)')
   .option('-s, --static', 'enable static server mode')
+  .option('-P, --pushstate', 'enable pushstate server mode (static mode only)')
   .option('-v, --verbose', 'enable verbose log')
   .option('-y, --proxy <url>', 'enable proxy server mode')
   .option('-C, --no-liveCSS', 'disable liveCSS')
@@ -68,6 +70,9 @@ var validate = exports.validate = function(conf) {
     }
     if (conf.preferLocal && conf.proxy === '') {
       throw 'The "prefer-local" option must be specified with "proxy" option';
+    }
+    if (conf.pushstate && !conf.static) {
+      throw 'The "pushstate" must be specified with "static" option';
     }
   }
   return conf;

--- a/lib/pushstate.js
+++ b/lib/pushstate.js
@@ -1,0 +1,29 @@
+"use strict";
+
+var log = require('./log')('static')
+  , fs = require('fs')
+  , path = require('path')
+  , url = require('url');
+
+function PushStateHandler(config) {
+  this.config = config;
+  this.root = path.resolve(this.config.dir);
+  this.init();
+}
+
+PushStateHandler.prototype.init = function() {
+  log.info('Push state active');
+};
+
+PushStateHandler.prototype.handle = function(req) {
+  // If the file does not exist, then send back / and let the client side
+  // router handle the path
+  var filePath = url.parse(req.url).pathname;
+  if (!fs.existsSync(path.join(this.root, filePath))) {
+    req.url = '/';
+  }
+  // Let the static file handler figure out what to return
+  return false;
+};
+
+module.exports = PushStateHandler;

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,6 +6,7 @@ var fs = require('fs')
   , ProxyHandler = require('./proxy')
   , send = require('send')
   , StaticHandler = require('./static')
+  , PushStateHandler = require('./pushstate')
   , url = require('url')
   , Watcher = require('./watcher')
   , WebSocketHandler = require('./websocket');
@@ -74,6 +75,9 @@ Server.prototype = {
     if (this.config.proxy) {
       handlers.push(new ProxyHandler(this.config));
     } else if (this.config.static) {
+      if (this.config.pushstate) {
+        handlers.push(new PushStateHandler(this.config));
+      }
       handlers.push(new StaticHandler(this.config));
     }
 


### PR DESCRIPTION
Add push state handling when using the static mode, for developing client side
applications with client side routing.

Added as -P option in the cli, to be used with -s.

What it just does is check if the request path is an existing file, and if it
isn't it will return the root path without redirecting to let the client handle
the routes.
