### PR TITLE
Add a configurable delay to reloading

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -16,6 +16,7 @@ var defaultValues = {
   port: 35729,
   preferLocal: false,
   proxy: '',
+  delay: 0,
   verbose: false,
   liveCSS: true,
   liveImg: true
@@ -31,6 +32,7 @@ program
   .option('-s, --static', 'enable static server mode')
   .option('-v, --verbose', 'enable verbose log')
   .option('-y, --proxy <url>', 'enable proxy server mode')
+  .option('-d, --delay <milliseconds>', 'add a delay in milliseconds', function(val){ return parseInt(val, 10); })
   .option('-C, --no-liveCSS', 'disable liveCSS')
   .option('-I, --no-liveImg', 'disable liveImg');
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -115,7 +115,12 @@ Server.prototype = {
     var self = this;
     this.watcher.on('change', function(file) {
       if (self.is_included(file)) {
-        self.notifyFileChange(file);
+        if (self.config.delay === 0) {
+          self.notifyFileChange(file);
+        } else {
+          log.info('delay', self.config.delay);
+          setTimeout(self.notifyFileChange.bind(self), self.config.delay, file);
+        }
       } else {
         log.info('skip: %s', file);
       }


### PR DESCRIPTION
 Resolves #18

I think this is especially useful when using livereloadx as a proxy. I'm using it to proxy mkdocs serve, which takes some time to actually rebuild the docs.