### PR TITLE
Enable caching npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: node_js
+
+sudo: false
+cache:
+  directories:
+    - node_modules
+
 node_js:
   - "0.10"
 before_script:


### PR DESCRIPTION
Setting sudo to false lets travis use the docker instances that don't allow sudo but start up faster and allow caching.