### PR TITLE
Feature: Single Page Application

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ cache:
     - node_modules
 
 node_js:
-  - "0.10"
+  - "4"
 before_script:
   - npm install -g grunt-cli

--- a/lib/config.js
+++ b/lib/config.js
@@ -17,7 +17,7 @@ var defaultValues = {
   port: 35729,
   preferLocal: false,
   proxy: '',
-  delay: 0,
+  delay: 10,
   verbose: false,
   liveCSS: true,
   liveImg: true
@@ -31,7 +31,7 @@ program
   .option('-p, --port <port>', 'change wait port', function(val){ return parseInt(val, 10); })
   .option('-l, --prefer-local', 'return a local file if it exists (proxy mode only)')
   .option('-s, --static', 'enable static server mode')
-  .option('-a, --spa', 'enable single-page application mode')
+  .option('-a, --spa', 'enable static and single-page application mode')
   .option('-v, --verbose', 'enable verbose log')
   .option('-y, --proxy <url>', 'enable proxy server mode')
   .option('-d, --delay <milliseconds>', 'add a delay in milliseconds', function(val){ return parseInt(val, 10); })
@@ -66,7 +66,12 @@ var validate = exports.validate = function(conf) {
     if (typeof conf[key] === 'number' && isNaN(conf[key])) {
       throw "Invalid value: " + key + " should be a number";
     }
-
+    if (conf.spa) {
+      conf.static = true;
+    }
+    if (conf.delay < 10) {
+      conf.delay = 10;
+    }
     if (conf.static && conf.proxy !== '') {
       throw 'The "static" option cannot be specified together with "proxy" option';
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,6 +13,7 @@ var defaultValues = {
     {type: 'exclude', pattern: '*'}
   ],
   static: false,
+  spa: false,
   port: 35729,
   preferLocal: false,
   proxy: '',
@@ -30,6 +31,7 @@ program
   .option('-p, --port <port>', 'change wait port', function(val){ return parseInt(val, 10); })
   .option('-l, --prefer-local', 'return a local file if it exists (proxy mode only)')
   .option('-s, --static', 'enable static server mode')
+  .option('-a, --spa', 'enable single-page application mode')
   .option('-v, --verbose', 'enable verbose log')
   .option('-y, --proxy <url>', 'enable proxy server mode')
   .option('-d, --delay <milliseconds>', 'add a delay in milliseconds', function(val){ return parseInt(val, 10); })

--- a/lib/server.js
+++ b/lib/server.js
@@ -72,7 +72,7 @@ Server.prototype = {
     var handlers = [ new LiveReloadJsHandler() ];
     if (this.config.proxy) {
       handlers.push(new ProxyHandler(this.config));
-    } else if (this.config.static) {
+    } else if (this.config.static || this.config.spa) {
       handlers.push(new StaticHandler(this.config));
     }
 
@@ -115,12 +115,10 @@ Server.prototype = {
     var self = this;
     this.watcher.on('change', function(file) {
       if (self.is_included(file)) {
-        if (self.config.delay === 0) {
-          self.notifyFileChange(file);
-        } else {
-          log.info('delay', self.config.delay);
-          setTimeout(self.notifyFileChange.bind(self), self.config.delay, file);
+        if (self.config.delay > 10) {
+          log.info('delay:', self.config.delay);
         }
+        setTimeout(self.notifyFileChange.bind(self), self.config.delay, file);
       } else {
         log.info('skip: %s', file);
       }

--- a/lib/static.js
+++ b/lib/static.js
@@ -2,6 +2,7 @@
 
 var EventEmitter = require('events').EventEmitter
   , fs = require('fs')
+  , http = require('http')
   , inject = require('./html').inject
   , log = require('./log')('static')
   , pause = require('pause')
@@ -20,6 +21,9 @@ function StaticHandler(config, onError) {
 
   if (this.config.static) {
     log.info("Enabled static mode.");
+  }
+  if (this.config.spa) {
+    log.info("Enabled SPA mode.");
   }
   log.debug('root dir: %s', this.root);
 
@@ -49,16 +53,36 @@ StaticHandler.prototype.handle = function(req, res) {
   }
 
   // Set error callback
-  if (this.onError) {
-    sendStream.on('error', function(err) {
+  sendStream.on('error', function(err) {
+    if (self.onError) {
       self.onError(req, res, err);
 
       // replay end & data events
       // (ref) connect/lib/middlewares/static.js
       //       https://gist.github.com/mikedeboer/3047099
       _pause.resume();
-    });
-  }
+      return;
+    }
+
+    // send index content in SPA mode
+    if (self.config.spa && path.match(/\/[^.\/]+\/?$/)) {
+      var baseUrl = 'http://localhost:' + self.config.port + '/';
+      log.debug('spa: ' + path + ' to ' + baseUrl);
+
+      http.get(baseUrl, function(rootRes) {
+        res.writeHead(rootRes.statusCode);
+        rootRes
+          .on('data', function(data) { res.write(data); })
+          .on('end', function() { res.end(); });
+      });
+      return;
+    }
+
+    // fallback to normal 404
+    res.writeHead(404);
+    res.write('Not Found');
+    res.end();
+  });
 
   sendStream
     .on('end', function() { log.debug('end'); self.emit('end'); })

--- a/lib/static.js
+++ b/lib/static.js
@@ -70,6 +70,7 @@ StaticHandler.prototype.handle = function(req, res) {
       log.debug('spa: ' + path + ' to ' + baseUrl);
 
       http.get(baseUrl, function(rootRes) {
+        res.setHeader('Content-Type', 'text/html');
         res.writeHead(rootRes.statusCode);
         rootRes
           .on('data', function(data) { res.write(data); })

--- a/lib/static.js
+++ b/lib/static.js
@@ -19,11 +19,11 @@ function StaticHandler(config, onError) {
   this.onError = onError;
   this.root = require('path').resolve(this.config.dir);
 
-  if (this.config.static) {
-    log.info("Enabled static mode.");
-  }
   if (this.config.spa) {
+    this.is_included = require('./filter').getMatcher(this.config.filter);
     log.info("Enabled SPA mode.");
+  } else if (this.config.static) {
+    log.info("Enabled static mode.");
   }
   log.debug('root dir: %s', this.root);
 
@@ -65,7 +65,7 @@ StaticHandler.prototype.handle = function(req, res) {
     }
 
     // send index content in SPA mode
-    if (self.config.spa && path.match(/\/[^.\/]+\/?$/)) {
+    if (self.config.spa && !self.is_included(path)) {
       var baseUrl = 'http://localhost:' + self.config.port + '/';
       log.debug('spa: ' + path + ' to ' + baseUrl);
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test": "test"
   },
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 4.0.0"
   },
   "scripts": {
     "test": "grunt"

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "url": "https://github.com/nitoyon/livereloadx/issues"
   },
   "dependencies": {
-    "commander": "~2.13.0",
+    "commander": "~2.3.0",
     "debug": "~3.1.0",
     "fsmonitor": "~ 0.2.4",
-    "http-proxy": "~ 1.16.2",
+    "http-proxy": "~ 0.8.7",
     "minimatch": "~ 3.0.4",
     "pause": "~ 0.1.0",
     "send": "~ 0.16.1",

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
     "url": "https://github.com/nitoyon/livereloadx/issues"
   },
   "dependencies": {
-    "commander": "~2.3.0",
-    "debug": "~2.0.0",
+    "commander": "~2.13.0",
+    "debug": "~3.1.0",
     "fsmonitor": "~ 0.2.4",
-    "http-proxy": "~ 0.8.7",
-    "minimatch": "~ 0.2.11",
-    "pause": "~ 0.0.1",
-    "send": "~ 0.9.3",
-    "ws": "~ 0.8.0"
+    "http-proxy": "~ 1.16.2",
+    "minimatch": "~ 3.0.4",
+    "pause": "~ 0.1.0",
+    "send": "~ 0.16.1",
+    "ws": "^4.0.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/test/public/index.html
+++ b/test/public/index.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+<p>index</p>
+</body>
+</html>

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -51,6 +51,12 @@ describe('config#parseArgv', function() {
     conf.should.have.property('static', true);
   });
 
+  it('set spa', function() {
+    var conf = config.parseArgv(['node', 'livereloadx', '-a']);
+    conf.should.have.property('static', true);
+    conf.should.have.property('spa', true);
+  });
+
   it('set proxy', function() {
     var conf = config.parseArgv(['node', 'livereloadx', '-y', 'http://example.com/']);
     conf.should.have.property('proxy', 'http://example.com/');

--- a/test/test.server.js
+++ b/test/test.server.js
@@ -24,7 +24,7 @@ describe('LiveReloadJsHandler', function() {
   it('should handle /livereload.js', function(done) {
     http.get('http://localhost:8000/livereload.js', function(res) {
       res.should.have.status(200);
-      res.should.have.header('content-type', 'application/javascript');
+      res.should.have.header('content-type', 'application/javascript; charset=UTF-8');
       res.on('data', function(data) {});
       res.on('end', function(chunk) {
         done();


### PR DESCRIPTION
Option `-a` / `--spa` enables Single Page Application (SPA) mode, e.g. URL rewriting to serve the index html. 

With this option the server is always also in "static" mode, and every 404 that doesn't match the include filter is replaced by 200 and the content of the index.

Also updated a few `package.json` dependencies.

Fixes #35 
