### PR TITLE
Fix socket exception when not handling error events

### DIFF
--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -15,7 +15,7 @@ function WebSocketHandler(config, options) {
 
 WebSocketHandler.prototype = {
   send: function(file, msg) {
-    log.info("notify: %s (%d client)", file, this.clients.length, 
+    log.info("notify: %s (%d client)", file, this.clients.length,
       this.clients.length > 2 ? 's' : '');
     this.clients.forEach(function(socket) {
       socket.send(msg);
@@ -43,6 +43,9 @@ WebSocketHandler.prototype = {
     });
     socket.on('close', function() {
       self.onClose(socket, remoteAddress);
+    });
+    socket.on('error', function(e) {
+      // ignore
     });
   },
 


### PR DESCRIPTION
This is due to a `ws` breaking change: https://github.com/websockets/ws/issues/1256

Fixes #37 