### PR TITLE
Make static mode usable when client port != server port

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -31,10 +31,9 @@ function bufLastSearchBody(buffer) {
   return -1;
 }
 
-var inject = exports.inject = function(buffer, port) {
+var inject = exports.inject = function(buffer) {
   // create snippet code
-  var snippet = "<script>document.write('<script src=\"http://' + (location.host || 'localhost').split(':')[0] + ':" +
-      port + "/livereload.js?snipver=2&port=" + port + "\"></' + 'script>')</script>";
+  var snippet = "<script>document.write('<script src=\"/livereload.js?snipver=2\"></' + 'script>')</script>";
 
   // find embed position
   var pos = bufLastSearchBody(buffer);

--- a/lib/static.js
+++ b/lib/static.js
@@ -107,7 +107,7 @@ StaticHandler.prototype.sendWithInjection = function(path, stat, stream) {
     stream.res.setHeader('Content-Type', 'text/html');
 
     // inject snippet
-    var buffer = inject(data, self.config.port);
+    var buffer = inject(data);
 
     // write to stream
     stream.res.setHeader('Content-Length', buffer.length);


### PR DESCRIPTION
When using in static mode, the port that livereloadx is serving pages on isn't necessarily the same port that clients are using to retrieve it. Examples: liveloadx is used from within a container which maps ports differently.  livereloadx is accessed through ssh port-forwarding which maps ports differently.

The implementation assumes that these ports will always be the same.

This PR removes the explicit ports so that the client ports will be used instead of the server ports.

The changes I made likely break another use case, so take them with a grain of salt.  